### PR TITLE
Add text around Server Name Indication

### DIFF
--- a/draft-ietf-radext-radiusdtls-bis.md
+++ b/draft-ietf-radext-radiusdtls-bis.md
@@ -73,6 +73,7 @@ An example for a worldwide roaming environment that uses RADIUS over TLS to secu
   These specifications have been merged into this document.
 * RFC6614 marked TLSv1.1 or later as mandatory, this specification requires TLSv1.2 as minimum and recommends usage of TLSv1.3
 * RFC6614 allowed usage of TLS compression, this document forbids it.
+* RFC6614 and RFC7360 did not have any reference to Server Name Indication, this specification requires clients to implement SNI.
 * RFC6614 only requires support for the trust model "certificates with PKIX". This document changes this. For servers, "certificates with PKIX" and "TLS-PSK" is now mandated and clients must implement one of the two.
 * The mandatory-to-implement cipher suites are not referenced directly, this is replaced by a pointer to the TLS BCP.
 * The specification regarding steps for certificate verification has been updated
@@ -228,6 +229,7 @@ Additionally, the following requirements have to be met for the (D)TLS session:
 * Negotiation of a cipher suite providing for confidentiality as well as integrity protection is REQUIRED.
 * The peers MUST NOT negotiate compression.
 * The session MUST be mutually authenticated (see {{mutual_auth}})
+* RADIUS/(D)TLS clients MUST support Server Name Indication in the (D)TLS handshake
 
 [^add_which]: TODO: Add text which recommendations of RFC9325 must be followed and why
 
@@ -814,6 +816,11 @@ The original specification of RADIUS/TLS does not forbid the usage of compressio
 As per {{RFC9325, Section 3.3}}, compression should not be used due to the possibility of compression-related attacks, unless the application protocol is proven to be not open to such attacks.
 Since some attributes of the RADIUS packets within the TLS tunnel contain values that an attacker could at least partially choose (i.e. username, MAC address or EAP message), there is a possibility for compression-related attacks, that could potentially reveal data in other RADIUS attributes through length of the TLS record.
 To circumvent this attack, this specification forbids the usage of TLS compression.
+
+The specification in {{RFC6614}} did not include any text around Server Name Indication (SNI).
+This is most likely due to the fact that the initial incentive of the specification was to just provide an easy-to-migrate-to security layer for existing RADIUS deployments.
+With the TLS layer, several features of TLS can be used to add deployment scenarios that otherwise would not have been possible.
+By adding Server Name Indication, a RAIDUS/(D)TLS server can now provide different services (i.e. access to different roaming consortia) under the same destination IP address and port, or could distinguish clients by the server name they use in the SNI extension of the TLS Client Hello and present a different server certificate or apply specific policies.
 
 # IANA Considerations
 

--- a/draft-ietf-radext-radiusdtls-bis.md
+++ b/draft-ietf-radext-radiusdtls-bis.md
@@ -338,6 +338,18 @@ In TLS-PSK operation at least the following parameters of the TLS connection sho
 
 [^pskid]: TODO: What is the correct term here? "PSK Identifier"? Probably not "TLS Identifier" as it was in RFC6614
 
+## Server Identity
+
+For clients it may be important to uniquely identify a server, i.e. to decide whether all connections to this server are down or if there is already an active connection to a server that was discovered using dynamic discovery described in {{RFC7585}}.
+In RADIUS/UDP a server identity could be simply described as the tuple of destination IP address and destination port.
+
+For RADIUS/(D)TLS, this distinction is not that simple, i.e. because different RADIUS servers are hidden behind a load balancer with one public IP address, and the load balancer dispatches the connections based on the Server Name Indication in the first TLS handshake record.
+
+Therefore, a RAIDUS/(D)TLS server is uniquely identified by the destination IP address, transport protocol (DTLS or TLS), destination port and server name as used in the Server Name Indication during the TLS handshake.
+Connections MUST NOT be treated as connections to the same servers if the presented server certificate is the same.
+Connections to the same destination IP address and port, but using different protocols SHOULD be treated as connections to different servers.
+Connectiosn to the same destination IP address and port and using the same transport protocol, but with different server names used in the Server Name Indication, including the combination where one connection did not use SNI, SHOULD be treated as connections to different servers.
+
 ## RADIUS Datagrams
 
 [^src_6614_2_5]


### PR DESCRIPTION
SNI was not part of RFC6614 or RFC7360.

This is possibly breaking backwards compatibility, so I don't want to change this without a discussion within the WG.

This Pull Request can be used to comment on aspects of the text.