### PR TITLE
Add explicit text explaining how to send RADIUS pkt via TLS

### DIFF
--- a/draft-ietf-radext-radiusdtls-bis.md
+++ b/draft-ietf-radext-radiusdtls-bis.md
@@ -541,6 +541,23 @@ These requirements reduce the possibility for a misbehaving client or server to 
 
 This section discusses all specifications that are only relevant for RADIUS/TLS.
 
+## Sending and receiving RAIDUS traffic
+
+The TLS layer of RADIUS/TLS provides a stream-based communication between the two peers instead of the traditional packet-based communication as with RADIUS/UDP.
+As a result, the way RADIUS packets are sent and received has to change.
+
+Instead of relying on packet borders to indicate the start of a new packet, this information is carried implicitly in the stream.
+
+After the TLS session is established, a RADIUS/(D)TLS peer MUST NOT send any data except for RADIUS packets over the connection.
+Since the RADIUS packet header contains a length field, the end of the RADIUS packet can be deduced.
+The next RADIUS packet MUST be sent directly after the RADIUS packet before, that is, the peers MUST NOT add padding before, between, or after RADIUS packets.
+
+When receiving RADIUS packets, a RADIUS/TLS node MUST determine the borders of RADIUS packet based on the length field in the RADIUS header.
+Note that, due to the stream architecture of TLS, it is possible that a RADIUS packet is first recieved only partially, and the remainder of the packet is contained in following fragments.
+Therefore, RADIUS/TLS peers MUST NOT assume that the packet length is invalid solely based on the currenlty available bytes in the stream.
+
+As an implementation note, it is RECOMMENDED that RADIUS/TLS implementations do not pass a single RADIUS packet to the TLS library in multiple fragments and instead assemble the RADIUS packet and pass it as one unit, in order to avoid unnecessary overhead when sending or receiving (especially if every new write generates a new TLS record) and wait times on the other peer.
+
 ## Duplicates and Retransmissions
 {:#duplicates_retransmissions}
 

--- a/draft-ietf-radext-radiusdtls-bis.md
+++ b/draft-ietf-radext-radiusdtls-bis.md
@@ -520,9 +520,9 @@ Implementations of this specification SHOULD treat the "silently discard" texts 
 That is, the implementation SHOULD send a TLS close notification and, in the case of RADIUS/TLS, the underlying TCP connection MUST be closed if any of the following circumstances are seen:
 
 * Connection from an unknown client
-* Packet where the RADIUS "Length" field is less than the minimum RADIUS packet length
-* Packet where the RADIUS "Length" field is more than the maximum RADIUS packet length
-* Packet where an Attribute "Length" field has the value of zero or one (0 or 1)
+* Packet where the RADIUS `Length` field is less than the minimum RADIUS packet length
+* Packet where the RADIUS `Length` field is more than the maximum RADIUS packet length
+* Packet where an Attribute `Length` field has the value of zero or one (0 or 1)
 * Packet where the attributes do not exactly fill the packet
 * Packet where the Request Authenticator fails validation (where validation is required)
 * Packet where the Response Authenticator fails validation (where validation is required)
@@ -541,18 +541,18 @@ These requirements reduce the possibility for a misbehaving client or server to 
 
 This section discusses all specifications that are only relevant for RADIUS/TLS.
 
-## Sending and receiving RAIDUS traffic
+## Sending and receiving RADIUS traffic
 
 The TLS layer of RADIUS/TLS provides a stream-based communication between the two peers instead of the traditional packet-based communication as with RADIUS/UDP.
 As a result, the way RADIUS packets are sent and received has to change.
 
-Instead of relying on packet borders to indicate the start of a new packet, this information is carried implicitly in the stream.
+Instead of relying on packet borders of the underlying transport protocol to indicate the start of a new packet, the RADIUS/TLS peers have to keep track of the packet borders by examining the header of the received RADIUS packets.
 
 After the TLS session is established, a RADIUS/(D)TLS peer MUST NOT send any data except for RADIUS packets over the connection.
-Since the RADIUS packet header contains a length field, the end of the RADIUS packet can be deduced.
+Since the RADIUS packet header contains a `Length` field, the end of the RADIUS packet can be deduced.
 The next RADIUS packet MUST be sent directly after the RADIUS packet before, that is, the peers MUST NOT add padding before, between, or after RADIUS packets.
 
-When receiving RADIUS packets, a RADIUS/TLS node MUST determine the borders of RADIUS packet based on the length field in the RADIUS header.
+When receiving RADIUS packets, a RADIUS/TLS node MUST determine the borders of RADIUS packet based on the `Length` field in the RADIUS header.
 Note that, due to the stream architecture of TLS, it is possible that a RADIUS packet is first recieved only partially, and the remainder of the packet is contained in following fragments.
 Therefore, RADIUS/TLS peers MUST NOT assume that the packet length is invalid solely based on the currenlty available bytes in the stream.
 


### PR DESCRIPTION
When looking over the document, I noticed that at no point we had an explicit specification that RADIUS packets are to be concatenated, without padding, and so on.
This fixes this, and it does nothing else than document explicitly what is inferred at many points in the document already.
(Theoretically, it is implied at many points in this document, that this is the case, but it's always better to have it explicitly in there)

Maybe this is worth adding in the "list of changes", maybe not, I'm open for suggestions on this.