### PR TITLE
Silent discard vs Protocol-Error

### DIFF
--- a/draft-ietf-radext-radiusdtls-bis.md
+++ b/draft-ietf-radext-radiusdtls-bis.md
@@ -533,12 +533,13 @@ That is, the implementation SHOULD send a TLS close notification and, in the cas
 * Packet where the Response Authenticator fails validation (where validation is required)
 * Packet where the Message-Authenticator attribute fails validation (when it occurs in a packet)
 
-After applying the above rules, there are still two situations where the previous specifications allow a packet to be "silently discarded" upon receipt:
+After applying the above rules, there are still situations where the previous specifications allow a packet to be "silently discarded" upon receipt, but in which a connection MAY remain open:
 
-* Packet with an invalid code field
+* Packet with an invalid code field {{radius_datagrams}}
 * Response packets that do not match any outstanding request
+* A server lacking the resources to process a request 
 
-In these situations, the (D)TLS connections MAY remain open, or they MAY be closed, as an implementation choice. However, the invalid packet MUST be silently discarded.
+For request packets that would have been silently discarded in the previous specifications, servers SHOULD reply with a Protocol-Error {{!RFC7930, Section 4}} message to avoid request ID exhaustion. In any case further processing the original request MUST stop.
 
 These requirements reduce the possibility for a misbehaving client or server to wreak havoc on the network.
 

--- a/draft-ietf-radext-radiusdtls-bis.md
+++ b/draft-ietf-radext-radiusdtls-bis.md
@@ -537,7 +537,7 @@ After applying the above rules, there are still situations where the previous sp
 
 * Packet with an invalid code field {{radius_datagrams}}
 * Response packets that do not match any outstanding request
-* A server lacking the resources to process a request 
+* A server lacking the resources to process a request
 
 For request packets that would have been silently discarded in the previous specifications, servers SHOULD reply with a Protocol-Error {{!RFC7930, Section 4}} message to avoid request ID exhaustion. In any case further processing the original request MUST stop.
 

--- a/draft-ietf-radext-radiusdtls-bis.md
+++ b/draft-ietf-radext-radiusdtls-bis.md
@@ -535,11 +535,11 @@ That is, the implementation SHOULD send a TLS close notification and, in the cas
 
 After applying the above rules, there are still situations where the previous specifications allow a packet to be "silently discarded" upon receipt, but in which a connection MAY remain open:
 
-* Packet with an invalid code field {{radius_datagrams}}
+* Packet with an invalid code field (see {{radius_datagrams}} for details)
 * Response packets that do not match any outstanding request
 * A server lacking the resources to process a request
 
-For request packets that would have been silently discarded in the previous specifications, servers SHOULD reply with a Protocol-Error {{!RFC7930, Section 4}} message to avoid request ID exhaustion. In any case further processing the original request MUST stop.
+For request packets that would have been silently discarded in the previous specifications, servers SHOULD reply with a Protocol-Error {{!RFC7930, Section 4}} message to avoid request ID exhaustion, and servers SHOULD include an Error-Cause attribute indicating the type of failure. In any case, further processing of the original request MUST stop.
 
 These requirements reduce the possibility for a misbehaving client or server to wreak havoc on the network.
 


### PR DESCRIPTION
Changes to section 4.5 require sending Protocol-Error instead of silently discrading packets. Apply the same provision to section 4.10.