### PR TITLE
Suggestions from 2025-10-03 radext emails

### DIFF
--- a/draft-ietf-radext-radiusdtls-bis.md
+++ b/draft-ietf-radext-radiusdtls-bis.md
@@ -514,7 +514,7 @@ The server may be able to receive and process another packet for that session vi
 It is difficult to make more recommendations for managing partially processed authentication sessions, as such recommendations depend strongly on the authentication method being used.
 As a result, further behavior is implementation defined and outside the scope of this specification.
 
-A home server which receives other kinds of packets (for example Accounting-Request, CoA-Request, Disconnect-Request) MAY finish processing outstanding requests, and then discard any response.
+A home server which receives other kinds of packets (for example Accounting-Request, CoA-NAK, Disconnect-NAK) MAY finish processing outstanding requests, and then discard any response.
 This behavior ensures that the desired action is still taken, even if the home server cannot inform the client of the result of that action.
 
 ## Malformed Packets and Unknown clients


### PR DESCRIPTION
These commits contain suggestions from my emails to radext on 2025-10-03. Most of them are clarifications. Main proposed changes are:
* remove all TLS renegotiations 3e474a3c3b4aedd70e838d07d2815455380e7604
* stop sending when Error-Cause is 406 'Unsupported Extension' 5916c67d5752b6cf3f32cb4195ed6776f6903e50

Commit 738ab370157f6ec29ec04250ccc7b5bae4b08dc9 also attempts to clarify RFC 6614 response types replaced with Protocol-Error response. My understanding is that the RFC 6614 behaviour is replaced, but please check 738ab370157f6ec29ec04250ccc7b5bae4b08dc9