### PR TITLE
radiusdtls-bis-09 - terminology

### DIFF
--- a/draft-ietf-radext-radiusdtls-bis.md
+++ b/draft-ietf-radext-radiusdtls-bis.md
@@ -616,14 +616,14 @@ Implemententors and operators should be aware of the possibility of fragmented U
 
 RADIUS/DTLS nodes MUST send exactly one RADIUS packet per DTLS record.
 This ensures that the RADIUS packets do not get fragmented at a point where a re-ordering of UDP packets would result in decoding failures.
-The DTLS specification mandates that a DTLS record must not span multiple UDP packets.
+The DTLS specification mandates that a DTLS record must not span multiple UDP datagrams.
 We note that a single UDP datagram may, however, contain multiple DTLS records.
 RADIUS/DTLS nodes MAY use this behavior to send multiple RADIUS packets in one UDP packet.
 
 For the receiving RADIUS/DTLS node, the length checks defined in {{RFC2865, Section 3}} still apply.
 That is, a receiving RADIUS/DTLS node MUST perform all the length checks, but MUST use the length of the decrypted payload of the DTLS record instead of the UDP packet length.
 Exactly one RADIUS packet is encapsulated in a DTLS record, and any data outside the range of the RADIUS length field within the decrypted payload of a single DTLS record MUST be treated as padding, as it would be with a RADIUS/UDP packet, and be ignored.
-For DTLS messages containing multiple DTLS records, each DTLS record MUST be parsed individually.
+For UDP datagrams containing multiple DTLS records, each DTLS record MUST be parsed individually.
 
 If a RADIUS packet should be re-transmitted, either as retransmission due to a missing response by the client or as retransmission of a cached response by the server, the RADIUS/DTLS peers MUST re-process the RADIUS packet through DTLS.
 That is, for the purpose of retransmissions, RADIUS/DTLS peers cache the RADIUS packet, as a RADIUS/UDP peer would, and not the DTLS record that contains the RADIUS packet.

--- a/draft-ietf-radext-radiusdtls-bis.md
+++ b/draft-ietf-radext-radiusdtls-bis.md
@@ -160,7 +160,7 @@ The calculation of security-related fields such as Response-Authenticator, Messa
 
 RADIUS/(D)TLS does not use separate ports for authentication, accounting and dynamic authorization changes.
 The source port is arbitrary.
-For considerations regarding the multi-purpose use of one port for authentication and accounting see {{radius_datagrams}}.
+For considerations regarding the multi-purpose use of one port for authentication and accounting see {{radius_packets}}.
 
 RADIUS/TLS servers MUST immediately start the TLS negotiation when a new connection to the RADIUS/TLS port is opened.
 They MUST close the connection and discard any data sent if the connecting client does not start a TLS negotiation or if the TLS negotiation fails at any point.
@@ -355,8 +355,8 @@ The re-authorization MUST give the same result as if a full handshake was perfor
 If cached data cannot be retrieved securely, resumption MUST NOT be done, by either immediately closing the connection or reverting to a full handshake.
 If a resumed session is closed immediately after being established, the RADIUS/(D)TLS client MUST NOT re-attempt session resumption but perform a full TLS handshake instead.
 
-## RADIUS Datagrams
-{:#radius_datagrams}
+## RADIUS packets
+{:#radius_packets}
 
 The RADIUS/(D)TLS specification does not change the client/server architecture of RADIUS.
 RADIUS/(D)TLS clients transmit the same packet types on the connection they initiated as a RADIUS/UDP client would, and RADIUS/(D)TLS servers transmit the same packet types on the connections the server has accepted as a RADIUS/UDP server would.
@@ -540,7 +540,7 @@ That is, the implementation SHOULD send a TLS close notification and, in the cas
 
 After applying the above rules, there are still situations where the previous specifications allow a packet to be "silently discarded" upon receipt, but in which a connection MAY remain open:
 
-* Packet with an invalid code field (see {{radius_datagrams}} for details)
+* Packet with an invalid code field (see {{radius_packets}} for details)
 * Response packets that do not match any outstanding request
 * A server lacking the resources to process a request
 


### PR DESCRIPTION
Reference to radext-gw mailing list message:
https://mailarchive.ietf.org/arch/msg/radext/X5lyKic2hrxGj9YZbZ66U8N0PDs/

I'd like to make sure the use of terms 'packet', 'message', 'datagram', etc. is uniform. My suggestion:
- RADIUS packet, RADIUS packet type  - from RFC 2865
- (D)TLS record - from the DTLS RFC 9147: a DTLS record always fits into one UDP datagram
- UDP datagram
- TCP segment
- IP packet (not currently used by the draft)

The two commits in this pull request are examples of what kind of terminology check-up I'm thinking of.