### PR TITLE
radiusdtls-bis-09 - Detecting Live Servers - absence of reply

### DIFF
--- a/draft-ietf-radext-radiusdtls-bis.md
+++ b/draft-ietf-radext-radiusdtls-bis.md
@@ -177,8 +177,8 @@ While the client may be able to deduce the operational state of the local server
 Within RADIUS, proxies typically only forward traffic between the NAS and RADIUS servers, and they do not generate their own response.
 As a result, when a NAS does not receive a response to a request, this could be the result of packet loss between the NAS and proxy, a problem on the proxy, loss between the RADIUS proxy and server, or a problem with the server.
 
-The absence of a reply can cause a client to deduce (incorrectly) that the proxy is unavailable.
-The client could then fail over to another server or conclude that no "live" servers are available (OKAY state in {{!RFC3539, Appendix A}}).
+The absence of a reply can cause a client to deduce, correctly or incorrectly, that the proxy is unavailable.
+In both cases the client could then fail over to another server or conclude that no "live" servers are available (OKAY state in {{!RFC3539, Appendix A}}).
 This situation is made even worse when requests are sent through a proxy to multiple destinations.
 Failures in one destination may result in service outages for other destinations, if the client erroneously believes that the proxy is unresponsive.
 


### PR DESCRIPTION
Clarify that the updated paragraph covers both the correct and incorrect cases. That is, when the client draws a conclusion that the server is unavailable, the conclusion may be correct or incorrect and the pargraph covers the both cases, not just the problems with the incorrect conclusion.

I've so far understood the paragraph to only address the problems that arise when the conclusion is incorrect. Janfred's comment clarified this is not the case and I hope the updated text is also clearer about this.