### PR TITLE
radiusdtls-bis-09 - Mostly DTLS specific updates

### DIFF
--- a/draft-ietf-radext-radiusdtls-bis.md
+++ b/draft-ietf-radext-radiusdtls-bis.md
@@ -212,8 +212,8 @@ Client implementations SHOULD implement both, but MUST implement at least one of
 ## (D)TLS requirements
 
 RADIUS/(D)TLS clients MUST establish a (D)TLS session immediately upon connecting to a new server.
-All data received over a TCP or TLS port is opaque for the RADIUS client or server application and must be passed to the TLS or DTLS implementation for processing.
-Closing TLS connections and discarding UDP datagrams are done as indicated by the (D)TLS implmentation.
+All data received over a TCP or UDP port assigned for RadSec is opaque for the RADIUS client or server application and must be handled by the TLS or DTLS implementation.
+Closing TLS connections and discarding invalid UDP datagrams are done by the (D)TLS implmentation.
 
 RadSec has no notion of negotiating (D)TLS in an ongoing communication.
 As RADIUS has no provisions for capability signaling, there is also no way for a server to indicate to a client that it should transition to using TLS or DTLS.


### PR DESCRIPTION
The overhead and retransmissions commits aim to clarify the existing text.

The third commit, '(D)TLS data is opaque', attempts to clarify that any data received over a TLS/TCP or DTLS/UDP port should be pushed to the (D)TLS implementation for processing. (D)TLS then tells what happens next.

The text the third commit adds is intended to say what Janfred commented earlier, [What we mean is: either it's DTLS or it gets thrown away](https://github.com/radext-wg/draft-ietf-radext-radiusdtls-bis/pull/56/commits/dcc543c0066b12fa3592a2d813a5fa8d9952fbb4#r2407121622), with the help of (D)TLS implementation. The removed text, from a point of RADIUS server implementator, reads as if the RADIUS server needs to understand what's the state of TLS connection or DTLS association.

In any case, I'd say the two removed paragraph should be in the 'Packet / Connection Handling' in case they are kept.