### PR TITLE
Clarify for reconnections

### DIFF
--- a/draft-ietf-radext-radiusdtls-bis.md
+++ b/draft-ietf-radext-radiusdtls-bis.md
@@ -463,7 +463,11 @@ RADIUS/(D)TLS clients may need to reconnect to a server that rejected their conn
 In contrast to RADIUS/UDP, RADIUS/(D)TLS establishes a (D)TLS session before transmitting any RADIUS packets.
 Therefore, in addition to retransmission of RADIUS packets, RADIUS/(D)TLS clients also have to deal with connection retries.
 
-Except in cases where an attempted resumption of a TLS session was closed by the RADIUS/(D)TLS server, RADIUS/(D)TLS clients MUST NOT immediately reconnect to a server after a failed connection attempt.  Typical reconnections MUST have a lower bound for the time in between retries.  The lower bound SHOULD be configurable, but MUST NOT be less than 0.5 seconds.  In cases where the server closes the connection on an attempted TLS session resumption, the client MUST NOT use TLS session resumption for the following connection attempt.
+Except in cases where an attempted resumption of a TLS session was closed by the RADIUS/(D)TLS server, RADIUS/(D)TLS clients MUST NOT immediately reconnect to a server after a failed connection attempt.
+A connection attempt is treated as failed if it fails at any point until a the (D)TLS session is established successfully.
+Typical reconnections MUST have a lower bound for the time in between retries.
+The lower bound SHOULD be configurable, but MUST NOT be less than 0.5 seconds.
+In cases where the server closes the connection on an attempted TLS session resumption, the client MUST NOT use TLS session resumption for the following connection attempt.
 
 RADIUS/(D)TLS clients MUST implement an algorithm for handling the timing of such reconnection attempts that includes an exponential back-off.
 Using an algorithm similar to the retransmission algorithm defined in {{RFC5080, Section 2.2.1}} is RECOMMENDED.


### PR DESCRIPTION
- Reword the exception, mostly because "iff" is not an English word ;-)
- Supply an absolute lower limit for configuring the lower limit of reconnection time, so that administrators don't set the lower limit to 0 seconds.