### PR TITLE
Add the change from "RADIUS/(D)TLS" to "RadSec" to list of changes

### DIFF
--- a/draft-ietf-radext-radiusdtls-bis.md
+++ b/draft-ietf-radext-radiusdtls-bis.md
@@ -964,7 +964,7 @@ Upon approval, IANA should update the Reference to radsec in the Service Name an
 
 The following list contains the most important changes from the previous specifications in {{RFC6613}} (RADIUS/TCP), {{RFC6614}} (RADIUS/TLS) and {{RFC7360}} (RADIUS/DTLS).
 
-* The protocol is now officially called "RadSec".
+* The protocols RADIUS/TLS and RADIUS/DTLS are now collectively referred to as RadSec.
 * {{?RFC6614}} referenced {{?RFC6613}} for TCP-related specification, RFC6613 on the other hand had some specification for RADIUS/TLS.
   These specifications have been merged into this document, and therefore removes {{RFC6613}} as normative reference.
 * RFC6614 marked TLSv1.1 or later as mandatory, this specification requires TLSv1.2 as minimum and recommends usage of TLSv1.3.


### PR DESCRIPTION
I think this is notable enough.

Maybe also include the previous terms (RADIUS/TLS and RADIUS/DTLS) explicitly here?