### PR TITLE
Drop RFC 6614 discussion of RADIUS/UDP client identification

### DIFF
--- a/draft-ietf-radext-radiusdtls-bis.md
+++ b/draft-ietf-radext-radiusdtls-bis.md
@@ -308,7 +308,7 @@ Further guidance on the usage of TLS-PSK in RadSec is given in {{?RFC9813}}.
 ## Connecting Client Identity
 
 In RADIUS/UDP, clients are uniquely identified by their IP addresses, as the shared secret is associated with the origin IP address.
-With RadSec multiple distinct RadSec clients can connect from the same IP address.
+With RadSec the shared secret has a fixed value and multiple distinct RadSec clients can connect from the same IP address.
 This requires changing the method of identifying individual clients from RADIUS/UDP.
 
 Depending on the trust model used, the RadSec client identity is determined as follows.


### PR DESCRIPTION
Clarify client identity determination in RadSec by removing the irrelevant discussion of how RADIUS/UDP does it. This text is a left over from RFC 6614.