### PR TITLE
Remove raw pubkey auth

### DIFF
--- a/draft-ietf-radext-radiusdtls-bis.md
+++ b/draft-ietf-radext-radiusdtls-bis.md
@@ -4,6 +4,7 @@ entity:
 title: "RadSec: RADIUS over Transport Layer Security (TLS) and Datagram Transport Layer Security (DTLS)"
 abbrev: "RadSec: RADIUS over TLS and DTLS"
 category: std
+
 obsoletes: 6614, 7360
 
 docname: draft-ietf-radext-radiusdtls-bis-latest


### PR DESCRIPTION
Raw public key was not part of 6614, we therefore should not introduce new auth methods here. Besides there are no (?) implementations.