### PR TITLE
Clarify retransmission text

### DIFF
--- a/draft-ietf-radext-radiusdtls-bis.md
+++ b/draft-ietf-radext-radiusdtls-bis.md
@@ -373,12 +373,13 @@ Where the connection to a RadSec server is configured to be static and always ke
 ### RADIUS packet retransmission
 {:#client_retransmission_timers}
 
-RadSec clients MUST implement retransmission timers for retransmitting RADIUS packets such as the ones defined in {{RFC5080, Section 2.2.1}}.
+RadSec clients MUST implement retransmission timers for retransmitting and abandoning RADIUS packets such as the ones defined in {{RFC5080, Section 2.2.1}}.
 Other algorithms than the one defined in {{RFC5080}} are possible, but any timer implementations MUST have similar properties of including jitter, exponential backoff and a maximum retransmission count (MRC) or maximum retransmission duration (MRD).
 
+For RADIUS/TLS clients, the timers, MRC or MRD specifically, must only be used to determine that a packet will most likely not receive an answer ever, for example because a packet loss has occurred in a later RADIUS hop or the home server ignores the RADIUS packet.
 As TLS is a reliable transport, RADIUS/TLS clients can only retry a packet if a connection closes without that packet receiving a reply, therefore the timers MUST NOT result in retransmission of any packet.
-A retry is the re-sending of the same content in a newly constructed RADIUS packet, where a retransmission is the re-sending of the exact same packet over the same connection to deal with packet loss on transport.
-Instead, the timers, MRC or MRD specifically, can be used to determine that a packet will most likely not receive an answer ever, for example because a packet loss has occurred in a later RADIUS hop or the home server ignores the RADIUS packet.
+To clarify the terminology: A retry is the re-sending of the same content in a newly constructed RADIUS packet, where a retransmission is the re-sending of the exact same packet over the same connection to deal with packet loss on transport.
+
 
 See {{duplicates_retransmissions}} for more discussion on retransmission behavior.
 


### PR DESCRIPTION
Especially in the paragraph for RADIUS/TLS I've moved the last sentence to the front which hopefully makes the paragraph more readable.

This addresses [comments on the Mailing list](https://mailarchive.ietf.org/arch/msg/radext/AihI-HB1QfC5IO00uq9WPvfutiA/)