### PR TITLE
Updated wording for retries and retransmission behavior

### DIFF
--- a/draft-ietf-radext-radiusdtls-bis.md
+++ b/draft-ietf-radext-radiusdtls-bis.md
@@ -380,7 +380,7 @@ For the following description, we use "retransmission" to mean the sending of th
 When a packet is retransmitted, the previously encoded packet contents are sent without change.
 When a packet is retried, it goes through the usual RADIUS processing (e.g. allocation of a new RADIUS ID, new Authenticator) and is re-encoded and re-signed.
 
-When a connection fails or is closed, a RadSec client SHOULD retry packets over a different connection.
+When a connection fails or is closed, a RadSec client SHOULD retry packets over a different connection, either a different connection to the same server or a different configured server in the same load-balancing/failover pool.
 In order to keep the timers consistent, the timers associated with a packet SHOULD NOT be changed when a packet is moved from one connection to another.
 A RadSec client MUST associate a packet with exactly one connection until either the connection is closed, in which case the association moves to a new connection, or the timers reach MRC or MRD, in which case the packet is discarded.
 


### PR DESCRIPTION
This is an alternative to #124, I've kept most of the text from that PR, changed the oder of the paragraphs and added some explanations.

Some discussion points:
* #124 suggested that the timers MUST NOT change when moving to a new connection. I'm not sure about this. The timers are local anyway, so at best this reduces the amount of time a proxy retries when the original client has long given up on the packet. I agree that this is usually useful, I'm just not sure if a MUST is right here, so I've changed it to a SHOULD NOT.
* #124 says that RADIUS/TLS clients MUST run the full timer algorithm, I don't agree. If MRC (maximum retransmission count) is set to 0/infinity, then only MRD is relevant, and MRD does not have a jitter. Therefore, the algorithm only needs to run if MRC is set, because then the jitter is included. I suspect that most clients that only run RADIUS/TLS will use MRD with a default value and just time out every packet after a fixed time (e.g. 30 seconds)
* The text says "SHOULD retry packets over a different connections" if a connection fails. Maybe add a sentence "if configured by the administrator" I've tried to come up with a good sentence, but I haven't found something good. Because it's either in the same load balancing/failover pool or a different connection to the same server.