### PR TITLE
one option is to partition out the accounting and authentication requests

### DIFF
--- a/draft-ietf-radext-radiusdtls-bis.md
+++ b/draft-ietf-radext-radiusdtls-bis.md
@@ -316,6 +316,8 @@ Further details of handling the Protocol-Error reply on the client side are outs
 Note that sending Protocol-Error in response to unwanted packets replaces the use of CoA-NAK, Disconnect-NAK and Accounting-Response in these situations as specified in {{RFC6614}}.
 See further details in {{unwanted_packet_handling}} below.
 
+RadSec clients, for both reliability and compatibility reasons, SHOULD not mix authentication and accounting requests within the same connection. RadSec clients SHOULD use a separate pool of connections on which to send accounting packets in the event the RadSec server does not support sending Protocol-Error.
+
 ## Detecting Live Servers
 
 RadSec implementations MUST utilize the existence of a TCP, TLS or DTLS connection where applicable in addition to the application-layer watchdog defined in {{!RFC3539, Section 3.4}} when determining the liveness of each connection.


### PR DESCRIPTION
Resubmission of #148 as requested in https://github.com/radext-wg/draft-ietf-radext-radiusdtls-bis/pull/148#issuecomment-3928570242 (...well GitHub autoclosed the original PR so opening a new one).

Recommendation text that clients should open a separate connection pool for authentication and accounting requests.

Suggested alternative text from [Peter Deacon on the mailing list](https://mailarchive.ietf.org/arch/msg/radext/zMDqOJWFrYF3LmUIcBm9OfSdODs/):
> RADIUS/TLS clients SHOULD open connections to servers for authentication on separate connections from accounting.  By separating authentication and accounting streams latency and availability concerns specific to authentication or accounting may be isolated from delaying or blocking the other.

As for the [comment](https://github.com/radext-wg/draft-ietf-radext-radiusdtls-bis/pull/148#issuecomment-3928570242):

> I don't think it is good, to make this behavior a recommendation, maybe it would be better to make it an optional suggestion?

I think making a 'MUST' for Protocol-Error which its-self is experimental and not widely deployed is fraught with danger.

Providing an implementer with an alternative that is clearly understood and really has the effect of re-establishing the separation that having separate ports provided for plain RADIUS/{TCP,UDP} is a bit of a win at a low cost. This works right now on existing RadSec deployments to provide the effect we are trying to get through Protocol-Error.

That said, I really am not that concerned, hopefully by the time it becomes an issue, https://datatracker.ietf.org/doc/html/draft-dekok-protocol-error will be out the door.